### PR TITLE
Update egress-qos to relabel all internal priorities to Cos 3

### DIFF
--- a/Google-Fiber/config.boot.poe
+++ b/Google-Fiber/config.boot.poe
@@ -285,7 +285,7 @@ interfaces {
         description "LAN"
         duplex auto
         poe {
-              output 48v
+              output off
         }
         speed auto
      }
@@ -301,7 +301,7 @@ interfaces {
         description "LAN"
         duplex auto
         poe {
-              output 48v
+              output off
         }       
         speed auto
     }
@@ -336,30 +336,22 @@ port-forward {
     auto-firewall enable
     hairpin-nat enable
     lan-interface switch0
-    rule 1 {
-        description "server ssh"
+    rule 10 {
+        description "Router SSH"
         forward-to {
-            address 192.168.1.10
+            address 192.168.1.1
             port 22
         }
-        original-port 22
+        original-port 2222
         protocol tcp_udp
     }
-    rule 2 {
-        description "server https"
+    rule 20 {
+        description "Router HTTPS"
         forward-to {
-            address 192.168.1.10
+            address 192.168.1.1
             port 443
         }
-        original-port 443
-        protocol tcp_udp
-    }
-    rule 4 {
-        description rtorrent
-        forward-to {
-            address 192.168.1.10
-        }
-        original-port 6881-6999
+        original-port 8080
         protocol tcp_udp
     }
     wan-interface eth0.2
@@ -374,6 +366,7 @@ service {
                 default-router 172.16.0.1
                 dns-server 8.8.8.8
                 dns-server 8.8.4.4
+                domain-name guest.example.com
                 lease 86400
                 start 172.16.0.10 {
                     stop 172.16.0.254
@@ -387,13 +380,10 @@ service {
                 dns-server 192.168.1.1
                 dns-server 8.8.8.8
                 dns-server 8.8.4.4
+                domain-name example.com
                 lease 86400
                 start 192.168.1.101 {
                     stop 192.168.1.254
-                }
-                static-mapping server {
-                    ip-address 192.168.1.10
-                    mac-address 4c:72:b9:42:fc:1d
                 }
             }
         }
@@ -447,13 +437,14 @@ service {
     }
 }
 system {
-    host-name edgy-loop
+    host-name UBNT-gateway
     login {
-        user redacted {
+        user ubnt {
             authentication {
-                encrypted-password redacted
+                encrypted-password $1$zKNoUbAo$gomzUbYvgyUMcD436Wo66.
                 plaintext-password ""
             }
+            full-name "UBNT Admin"
             level admin
         }
     }
@@ -483,19 +474,6 @@ system {
             vlan enable
         }
     }
-    static-host-mapping {
-        host-name edgy {
-            inet 192.168.1.1
-        }
-        host-name server {
-            alias nzb
-            alias tv
-            alias index
-            alias torrent
-            alias plex
-            inet 192.168.1.10
-        }
-    }
     package {
         repository wheezy {
             components "main contrib non-free"
@@ -515,7 +493,7 @@ system {
             }
         }
     }
-    time-zone America/Chicago
+    time-zone America/Denver
     traffic-analysis {
         dpi disable
         export enable

--- a/Google-Fiber/config.boot.poe
+++ b/Google-Fiber/config.boot.poe
@@ -250,7 +250,7 @@ interfaces {
                 }
                 rapid-commit enable
             }
-            egress-qos 0:3
+            egress-qos "0:3 1:3 2:3 3:3 4:3 5:3 6:3 7:3"
             firewall {
                 in {
                     ipv6-name WANv6_IN

--- a/Google-Fiber/config.boot.poe
+++ b/Google-Fiber/config.boot.poe
@@ -285,7 +285,7 @@ interfaces {
         description "LAN"
         duplex auto
         poe {
-              output off
+              output 48v
         }
         speed auto
      }
@@ -301,7 +301,7 @@ interfaces {
         description "LAN"
         duplex auto
         poe {
-              output off
+              output 48v
         }       
         speed auto
     }
@@ -336,22 +336,30 @@ port-forward {
     auto-firewall enable
     hairpin-nat enable
     lan-interface switch0
-    rule 10 {
-        description "Router SSH"
+    rule 1 {
+        description "server ssh"
         forward-to {
-            address 192.168.1.1
+            address 192.168.1.10
             port 22
         }
-        original-port 2222
+        original-port 22
         protocol tcp_udp
     }
-    rule 20 {
-        description "Router HTTPS"
+    rule 2 {
+        description "server https"
         forward-to {
-            address 192.168.1.1
+            address 192.168.1.10
             port 443
         }
-        original-port 8080
+        original-port 443
+        protocol tcp_udp
+    }
+    rule 4 {
+        description rtorrent
+        forward-to {
+            address 192.168.1.10
+        }
+        original-port 6881-6999
         protocol tcp_udp
     }
     wan-interface eth0.2
@@ -366,7 +374,6 @@ service {
                 default-router 172.16.0.1
                 dns-server 8.8.8.8
                 dns-server 8.8.4.4
-                domain-name guest.example.com
                 lease 86400
                 start 172.16.0.10 {
                     stop 172.16.0.254
@@ -380,10 +387,13 @@ service {
                 dns-server 192.168.1.1
                 dns-server 8.8.8.8
                 dns-server 8.8.4.4
-                domain-name example.com
                 lease 86400
                 start 192.168.1.101 {
                     stop 192.168.1.254
+                }
+                static-mapping server {
+                    ip-address 192.168.1.10
+                    mac-address 4c:72:b9:42:fc:1d
                 }
             }
         }
@@ -437,14 +447,13 @@ service {
     }
 }
 system {
-    host-name UBNT-gateway
+    host-name edgy-loop
     login {
-        user ubnt {
+        user redacted {
             authentication {
-                encrypted-password $1$zKNoUbAo$gomzUbYvgyUMcD436Wo66.
+                encrypted-password redacted
                 plaintext-password ""
             }
-            full-name "UBNT Admin"
             level admin
         }
     }
@@ -474,6 +483,19 @@ system {
             vlan enable
         }
     }
+    static-host-mapping {
+        host-name edgy {
+            inet 192.168.1.1
+        }
+        host-name server {
+            alias nzb
+            alias tv
+            alias index
+            alias torrent
+            alias plex
+            inet 192.168.1.10
+        }
+    }
     package {
         repository wheezy {
             components "main contrib non-free"
@@ -493,7 +515,7 @@ system {
             }
         }
     }
-    time-zone America/Denver
+    time-zone America/Chicago
     traffic-analysis {
         dpi disable
         export enable


### PR DESCRIPTION
Before this change, only packets with internal priority of 0 were relabeled to 3. Some traffic (like SCP or torrent) has a different internal label, and failing to relabel it limits its speed to 10Mbps (through tests on Google Fiber Austin). So, this change maps all possible labels to output CoS 3.