### PR TITLE
Fix egress-qos so all priorities are mapped

### DIFF
--- a/Google-Fiber/config.boot.erl
+++ b/Google-Fiber/config.boot.erl
@@ -247,7 +247,7 @@ interfaces {
                 }
                 rapid-commit enable
             }
-            egress-qos 0:3
+            egress-qos "0:3 1:3 2:3 3:3 4:3 5:3 6:3 7:3"
             firewall {
                 in {
                     ipv6-name WANv6_IN

--- a/Google-Fiber/config.boot.erx
+++ b/Google-Fiber/config.boot.erx
@@ -242,7 +242,7 @@ interfaces {
                 }
                 rapid-commit enable
             }
-            egress-qos 0:3
+            egress-qos "0:3 1:3 2:3 3:3 4:3 5:3 6:3 7:3"
             firewall {
                 in {
                     ipv6-name WANv6_IN

--- a/Google-Fiber/config.boot.poe
+++ b/Google-Fiber/config.boot.poe
@@ -250,7 +250,7 @@ interfaces {
                 }
                 rapid-commit enable
             }
-            egress-qos 0:3
+            egress-qos "0:3 1:3 2:3 3:3 4:3 5:3 6:3 7:3"
             firewall {
                 in {
                     ipv6-name WANv6_IN


### PR DESCRIPTION
to 802.1q CoS 3, instead of only the default priority 0.

Without this change, I observed SCP uploads limited to ~1MB/s on my gigabit Google Fiber. I investigated and found my EdgeRouter-POE-5 running 1.9.1 was using the IP TOS/DSCP field value set by the SCP client to map packets to different internal SO_PRIORITY/skb_priority than the default of 0, so the 0:3 egress-qos mapping didn't apply. SCP frames were going out without the correct 802.1q CoS for Google's network.

After making this change, my SCP uploads run at ~90MB/s.

I observed this on the Austin, Texas Google Fiber network. I don't know if the 802.1q CoS value is as critical in all regions but it definitely matters in Austin at the moment.

See also the solution in https://community.ubnt.com/t5/EdgeMAX/egress-qos/td-p/1478090
