### PR TITLE
Use ISP's NTP servers

### DIFF
--- a/Charter/README.md
+++ b/Charter/README.md
@@ -72,6 +72,19 @@ https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-How-to-further-customize
 
 Be extremely careful when creating or editing a `config.gateway.json` file, as including malformed configuration options in a `config.gateway.json` file can lead to a provisioning loop. This is considered an advanced configuration option.
 
+# Timekeeping
+
+The `system ntp` configuration includes
+    server ntp.charter.com {
+    }
+This is mixed with [NTP Pool Project](https://www.ntppool.org/) servers because you could enjoy better quality time from a server nearer you in the network topology. Passing through fewer network hops could introduce lower latency and jitter than using a server that's nearer geographically.
+
+In a chat conversation June 1 2021 with Spectrum Support, the agent said `ntp.charter.com` does not serve [leap-smeared time](https://docs.ntpsec.org/latest/leapsmear.html), which should not be mixed with non-leap-smearing servers. Alas, the agent could not provide a public document reflecting this. If you discover symptoms attributable to leap smearing, change this to
+    server ntp.charter.com {
+        noselect
+    }
+Alternatively, leave `ntp.charter.com` selected, and add `noselect` to each of the pool servers configured.
+
 # Charter Spectrum IPv6 Considerations
 
 Based on the most recent [IPv6 information from Charter](http://www.spectrum.net/support/internet/ipv6/), residential customers should be requesting IPv6 addressing
@@ -87,8 +100,15 @@ Change `eth0` as needed to match your configuration's WAN interface.
 
 # Test IPv6 Connectivity
 Test your connection for IPv6 support by visiting these websites:
-* http://ipv6-test.com/
-* http://test-ipv6.com/
+* https://ipv6-test.com/
+* https://test-ipv6.com/
 * http://testmyipv6.com/
-* http://ipv6test.google.com/
-* http://ipv6leak.com/
+* https://ipv6test.google.com/
+* https://ipv6leak.com/
+* https://ip6.me/
+* https://ipinfo.io/
+* https://ifconfig.me/
+* https://ifconfig.co/
+* https://api64.ipify.org/
+* https://ident.me/
+* https://checkip.amazonaws.com/

--- a/Charter/README.md
+++ b/Charter/README.md
@@ -75,14 +75,18 @@ Be extremely careful when creating or editing a `config.gateway.json` file, as i
 # Timekeeping
 
 The `system ntp` configuration includes
+
     server ntp.charter.com {
     }
+
 This is mixed with [NTP Pool Project](https://www.ntppool.org/) servers because you could enjoy better quality time from a server nearer you in the network topology. Passing through fewer network hops could introduce lower latency and jitter than using a server that's nearer geographically.
 
 In a chat conversation June 1 2021 with Spectrum Support, the agent said `ntp.charter.com` does not serve [leap-smeared time](https://docs.ntpsec.org/latest/leapsmear.html), which should not be mixed with non-leap-smearing servers. Alas, the agent could not provide a public document reflecting this. If you discover symptoms attributable to leap smearing, change this to
+
     server ntp.charter.com {
         noselect
     }
+
 Alternatively, leave `ntp.charter.com` selected, and add `noselect` to each of the pool servers configured.
 
 # Charter Spectrum IPv6 Considerations

--- a/Charter/config.boot.erl
+++ b/Charter/config.boot.erl
@@ -405,6 +405,8 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server ntp.charter.com {
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Charter/config.boot.erx
+++ b/Charter/config.boot.erx
@@ -411,6 +411,8 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server ntp.charter.com {
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Charter/config.boot.poe
+++ b/Charter/config.boot.poe
@@ -448,6 +448,8 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server ntp.charter.com {
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Comcast/README.md
+++ b/Comcast/README.md
@@ -75,14 +75,18 @@ Be extremely careful when creating or editing a `config.gateway.json` file, as i
 # Timekeeping
 
 The `system ntp` configuration includes
+
     server time.comcast.com {
     }
+
 This is mixed with [NTP Pool Project](https://www.ntppool.org/) servers because you could enjoy better quality time from a server nearer you in the network topology. Passing through fewer network hops could introduce lower latency and jitter than using a server that's nearer geographically.
 
 In a chat conversation June 1 2021 with Xfinity Support, the agent could not confirm whether or not `time.comcast.com` serves [leap-smeared time](https://docs.ntpsec.org/latest/leapsmear.html), which should not be mixed with non-leap-smearing servers. If you discover symptoms attributable to leap smearing, change this to
+
     server time.comcast.com {
         noselect
     }
+
 Alternatively, leave `time.comcast.com` selected, and add `noselect` to each of the pool servers configured. If you want more servers topologically nearby, you might also specify `time.comcast.net`, `time.xfinity.com`, and `time.xfinity.net`.
 
 # Comcast Xfinity IPv6 Considerations

--- a/Comcast/README.md
+++ b/Comcast/README.md
@@ -72,6 +72,19 @@ https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-How-to-further-customize
 
 Be extremely careful when creating or editing a `config.gateway.json` file, as including malformed configuration options in a `config.gateway.json` file can lead to a provisioning loop. This is considered an advanced configuration option.
 
+# Timekeeping
+
+The `system ntp` configuration includes
+    server time.comcast.com {
+    }
+This is mixed with [NTP Pool Project](https://www.ntppool.org/) servers because you could enjoy better quality time from a server nearer you in the network topology. Passing through fewer network hops could introduce lower latency and jitter than using a server that's nearer geographically.
+
+In a chat conversation June 1 2021 with Xfinity Support, the agent could not confirm whether or not `time.comcast.com` serves [leap-smeared time](https://docs.ntpsec.org/latest/leapsmear.html), which should not be mixed with non-leap-smearing servers. If you discover symptoms attributable to leap smearing, change this to
+    server time.comcast.com {
+        noselect
+    }
+Alternatively, leave `time.comcast.com` selected, and add `noselect` to each of the pool servers configured. If you want more servers topologically nearby, you might also specify `time.comcast.net`, `time.xfinity.com`, and `time.xfinity.net`.
+
 # Comcast Xfinity IPv6 Considerations
 
 Based on the most recent [IPv6 information from Comcast](http://www.comcast6.net/), residential customers should be requesting IPv6 addressing with a prefix length of `/60` (which is what is used in these examples). Commercial customers should use a prefix length of `/56`.
@@ -86,8 +99,15 @@ Change `eth0` as needed to match your configuration's WAN interface.
 
 # Test IPv6 Connectivity
 Test your connection for IPv6 support by visiting these websites:
-* http://ipv6-test.com/
-* http://test-ipv6.com/
+* https://ipv6-test.com/
+* https://test-ipv6.com/
 * http://testmyipv6.com/
-* http://ipv6test.google.com/
-* http://ipv6leak.com/
+* https://ipv6test.google.com/
+* https://ipv6leak.com/
+* https://ip6.me/
+* https://ipinfo.io/
+* https://ifconfig.me/
+* https://ifconfig.co/
+* https://api64.ipify.org/
+* https://ident.me/
+* https://checkip.amazonaws.com/

--- a/Comcast/config.boot.erl
+++ b/Comcast/config.boot.erl
@@ -399,6 +399,8 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server time.comcast.com {
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Comcast/config.boot.erx
+++ b/Comcast/config.boot.erx
@@ -405,6 +405,8 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server time.comcast.com {
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Comcast/config.boot.poe
+++ b/Comcast/config.boot.poe
@@ -442,6 +442,8 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server time.comcast.com {
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Google-Fiber/README.md
+++ b/Google-Fiber/README.md
@@ -89,9 +89,11 @@ For Google TV users only, I now recommend installing a simple Gigabit switch, su
 # Timekeeping
 
 The `system ntp` configuration includes
+
     server time.google.com {
         noselect
     }
+
 This is marked as unused because [Google Public NTP](https://developers.google.com/time) serves [leap-smeared time](https://developers.google.com/time/smear), and Google "recommend(s) that you don’t configure Google Public NTP together with non-leap-smearing NTP servers" such as those of the [NTP Pool Project](https://www.ntppool.org/).
 
 By using Google Public NTP you could enjoy better quality time from a server nearer you in the network topology. Passing through fewer network hops could introduce lower latency and jitter than using a server that's nearer geographically. To switch from the NTP Pool Project's servers to Google Public NTP, remove `noselect` from the configuration for `time.google.com`, and add `noselect` to each of the other servers' configurations.

--- a/Google-Fiber/README.md
+++ b/Google-Fiber/README.md
@@ -86,6 +86,16 @@ My `config.boot` files used to include elements (inclduing igmp-proxy and multic
 
 For Google TV users only, I now recommend installing a simple Gigabit switch, such as the [NETGEAR GS105NA](http://amzn.to/2nIAaVZ), "downstream" of the Google Fiber jack, then connecting both the Google Fiber TV box and the EdgeRouter's WAN port to separate ports on the Gigabit switch. This separates the Google TV service from the EdgeRouter and will allow everything to function normally without having to chase down changing settings at Google's whim.
 
+# Timekeeping
+
+The `system ntp` configuration includes
+    server time.google.com {
+        noselect
+    }
+This is marked as unused because [Google Public NTP](https://developers.google.com/time) serves [leap-smeared time](https://developers.google.com/time/smear), and Google "recommend(s) that you don’t configure Google Public NTP together with non-leap-smearing NTP servers" such as those of the [NTP Pool Project](https://www.ntppool.org/).
+
+By using Google Public NTP you could enjoy better quality time from a server nearer you in the network topology. Passing through fewer network hops could introduce lower latency and jitter than using a server that's nearer geographically. To switch from the NTP Pool Project's servers to Google Public NTP, remove `noselect` from the configuration for `time.google.com`, and add `noselect` to each of the other servers' configurations.
+
 # Google Fiber IPv6 Considerations
 Based on the most recent IPv6 information from Google, residential customers should be requesting IPv6 addressing
 with a prefix length of `/64` (which is what is used in these examples).
@@ -100,11 +110,18 @@ Change `eth0.2` as needed to match your configuration's VLAN-tagged WAN interfac
 
 # Test IPv6 Connectivity
 Test your connection for IPv6 support by visiting these websites:
-* http://ipv6-test.com/
-* http://test-ipv6.com/
+* https://ipv6-test.com/
+* https://test-ipv6.com/
 * http://testmyipv6.com/
-* http://ipv6test.google.com/
-* http://ipv6leak.com/
+* https://ipv6test.google.com/
+* https://ipv6leak.com/
+* https://ip6.me/
+* https://ipinfo.io/
+* https://ifconfig.me/
+* https://ifconfig.co/
+* https://api64.ipify.org/
+* https://ident.me/
+* https://checkip.amazonaws.com/
 
 # Support
 Support for using these files is on this thread in the UBNT EdgeMax forums:

--- a/Google-Fiber/config.boot.erl
+++ b/Google-Fiber/config.boot.erl
@@ -415,6 +415,9 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server time.google.com {
+            noselect
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Google-Fiber/config.boot.erx
+++ b/Google-Fiber/config.boot.erx
@@ -416,6 +416,9 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server time.google.com {
+            noselect
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/Google-Fiber/config.boot.poe
+++ b/Google-Fiber/config.boot.poe
@@ -453,6 +453,9 @@ system {
     name-server 8.8.8.8
     name-server 8.8.4.4
     ntp {
+        server time.google.com {
+            noselect
+        }
         server 0.ubnt.pool.ntp.org {
         }
         server 1.ubnt.pool.ntp.org {

--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ Change `eth0` as needed to match your configuration's WAN interface.
 
 # Test IPv6 Connectivity
 Test your connection for IPv6 support by visiting these websites:
-* http://ipv6-test.com/
-* http://test-ipv6.com/
+* https://ipv6-test.com/
+* https://test-ipv6.com/
 * http://testmyipv6.com/
-* http://ipv6test.google.com/
-* http://ipv6leak.com/
+* https://ipv6test.google.com/
+* https://ipv6leak.com/
+* https://ip6.me/
+* https://ipinfo.io/
+* https://ifconfig.me/
+* https://ifconfig.co/
+* https://api64.ipify.org/
+* https://ident.me/
+* https://checkip.amazonaws.com/


### PR DESCRIPTION
Use ISP's NTP servers, with warnings about leap smearing (might be deviating too far from this repo's IPv6 focus)
Suggest more IPv6 test points